### PR TITLE
redo-subst

### DIFF
--- a/Documentation/redo-subst.md
+++ b/Documentation/redo-subst.md
@@ -1,0 +1,39 @@
+% redo-subst(1) Redo 0.00
+% Andreas Krennmair <ak@synflood.at>
+% 2011-01-16
+
+# NAME
+
+redo-subst - substitute file suffixes
+
+# SYNOPSIS
+
+redo-subst suffix replacement [sources...]
+
+
+# DESCRIPTION
+
+redo-subst takes a file suffix, a replacement suffix and
+a list of file names on which the file suffix shall be substituted
+with the replacement suffix. For every file name that ends
+with the specified suffix, the suffix is removed, the
+replacement suffix is appended and the resulting file name
+is printed out. File names whose suffix does not match
+are printed out unmodified.
+
+# REDO
+
+Part of the `redo`(1) suite.
+    
+# CREDITS
+
+The original concept for `redo` was created by D. J.
+Bernstein and documented on his web site
+(http://cr.yp.to/redo.html).  This independent implementation
+was created by Avery Pennarun and you can find its source
+code at http://github.com/apenwarr/redo.
+
+
+# SEE ALSO
+
+`redo`(1)

--- a/redo-subst
+++ b/redo-subst
@@ -1,0 +1,1 @@
+redo-subst.py

--- a/redo-subst.py
+++ b/redo-subst.py
@@ -1,0 +1,13 @@
+#!/usr/bin/python
+import sys, os
+
+if len(sys.argv) < 4:
+	sys.exit(0)
+
+fromsuffix = sys.argv[1]
+tosuffix  = sys.argv[2]
+
+for file in sys.argv[3:]:
+	if file[-len(fromsuffix):] == fromsuffix:
+		file = file[0:-len(fromsuffix)] + tosuffix
+	print file


### PR DESCRIPTION
I implemented a simple command redo-subst that helps with auto-generating lists of dependencies in certain cases. It takes two file suffixes and a list of file names, and generates a list of file names where the (matching) first suffix is substituted with the second suffix.

This allows constructs like these but in a more reliable fashion than ls ... | sed ...:

```
DEPS=`redo-subst .c .o foo/*.c`
redo-ifchange $DEPS
cc -o $3 $DEPS
```

This is also basically the first real Python code that I wrote in my life. If the code is too bad, feel free to correct me.

Best regards,
Andreas
