### PR TITLE
Added package.do to create a system package

### DIFF
--- a/package.do
+++ b/package.do
@@ -1,7 +1,5 @@
 exec >&2
 
-DESTDIR="$(pwd)/root" redo install
-
 if ! which fpm >/dev/null 2>&1; then
   echo "To build system packages, you need fpm"
   echo "You can get it using the ruby gem 'fpm':"
@@ -22,7 +20,8 @@ fi
 
 desc=$(git describe)
 
-set -x
+DESTDIR="$(pwd)/root" redo install
+
 fpm \
   --name redo \
   --version ${desc#redo-} \


### PR DESCRIPTION
I added a target: package.do that creates a system package. rpm on fedora (and I suppose other rpm distributions) and deb on debian (I just tested on debian). I used for that the excellent tool fpm.

I thought it would be easier for people to install redo if they had a package. And as it seems redo is currently not included in most distributions, we had to create the package on our own. With this patch, it will be just a little easier.

just

```
./redo package
```

and then install your package using normal means. You're set.

What do you think ?

Mildred
