### PR TITLE
Fixed ps output in redo scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1402,21 +1402,20 @@ use of them.)
 
 # The output of 'ps ax' is ugly because of the python interpreter!
 
-FIXME:
-Yes, this is a general problem with python.  All the lines
-in 'ps' end up looking like
+If the [setproctitle](http://code.google.com/p/py-setproctitle/) module is
+installed, redo will use it in its script to clean up the displayed title. The
+module is also available in many distributions. A `ps afx` output would look
+like:
 
-	28460 pts/2 Sl 0:00 /usr/bin/python /path/to/redo-ifchange stuff...
+	...
+	23461 pts/21   T      0:00      \_ make test
+	23462 pts/21   T      0:00      |   \_ redo test
+	23463 pts/21   T      0:00      |       \_ sh -e test.do test test test.redo2.tmp
+	23464 pts/21   T      0:00      |           \_ redo-ifchange _all
+	23465 pts/21   T      0:00      |               \_ sh -e _all.do _all _all _all.redo2.tmp
+	...
 
-...which means that the "stuff..." part is often cut off on
-the right hand side.  There are gross workarounds to fix
-this in python, but the easiest fix will be to just rewrite
-redo in C.  Then it'll look like this:
 
-	28460 pts/2 Sl 0:00 redo-ifchange stuff...
-
-...the way it should.
-	
 
 # Are there examples?
 

--- a/state.py
+++ b/state.py
@@ -3,6 +3,17 @@ import vars
 from helpers import unlink, close_on_exec, join
 from log import warn, err, debug2, debug3
 
+# When the module is imported, change the process title.
+# We do it here because this module is imported by all the scripts.
+try:
+	from setproctitle import setproctitle
+except ImportError:
+	pass
+else:
+	cmdline = sys.argv[:]
+	cmdline[0] = os.path.splitext(os.path.basename(cmdline[0]))[0]
+	setproctitle(" ".join(cmdline))
+
 SCHEMA_VER=1
 TIMEOUT=60
 


### PR DESCRIPTION
Hello,

the setproctitle module can be used to change the process title of a python script. I've patched state.py (so that all the script automatically use it) to change the scripts name at import time to something more readable.

If the setproctitle module is not available, then nothing happens: the dependency is optional.

The module is already packaged is several linux distros.

http://code.google.com/p/py-setproctitle/

I'm the module author, so if you have any questions, just ask.

Cheers!
