### PR TITLE
Search for .redo directory starts with parent directory.

### DIFF
--- a/vars_init.py
+++ b/vars_init.py
@@ -24,7 +24,7 @@ def init(targets):
         base = os.path.commonprefix([os.path.abspath(os.path.dirname(t))
                                      for t in targets] + [os.getcwd()])
         bsplit = base.split('/')
-        for i in range(len(bsplit)-1, 0, -1):
+        for i in range(len(bsplit), 0, -1):
             newbase = '/'.join(bsplit[:i])
             if os.path.exists(newbase + '/.redo'):
                 base = newbase


### PR DESCRIPTION
Hi,

I've found what I think is a problem with redo's algorithm for finding its .redo directory.  It searches up the tree starting with the parent of the current directory.  If it doesn't find a .redo it uses the current directory creating .redo if necessary.

So, if you mistakenly type redo in your home directory, redo will create a database there, and then use that database in preference to the project's .redo.  Unless you redo in a subdirectory of the project in which case it uses the correct database and things get really confused.

This patch simply removes a -1 so that the search starts with the current directory.

I also feel like redo should check if the requested action exists before it creates a database so that it doesn't create the database in the home directory. I may look at fixing that, but for the moment I'm preventing database creation with a .redo file in my home directory.

Thanks,
Adam.
