### PR TITLE
Add redo-static

### DIFF
--- a/redo-static
+++ b/redo-static
@@ -1,0 +1,1 @@
+redo-static.py

--- a/redo-static.py
+++ b/redo-static.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python
+import sys
+
+import vars_init
+vars_init.init([])
+
+import state
+for n in sys.argv[1:]:
+    f = state.File(name=n)
+    f.set_static()
+    f.save()
+state.commit()


### PR DESCRIPTION
redo-static marks each argument as static (i.e an input sources),
even if they were previously marked as generated.

It's not exactly elegant, but I've encountered two cases where it seems necessary:
1. `foo.do` generates `foo`, but then the build is restructured and `foo` becomes a source (non-generated) file. `redo` warns that you've modified a generated file.
2. `redo foo` triggers `default.do` to build `foo`, but `default.do` doesn't know how to build `foo` (it's supposed to be a source file). This is probably a bug, discussed here: https://groups.google.com/forum/#!topic/redo-list/6_XvB6ZKlZ8
