### PR TITLE
Avoid bashism >&file

### DIFF
--- a/t/000-set-minus-e/all.do
+++ b/t/000-set-minus-e/all.do
@@ -1,4 +1,4 @@
 rm -f log
-redo fatal >&/dev/null || true
+redo fatal >/dev/null 2>&1 || true
 
 [ "$(cat log)" = "ok" ] || exit 5

--- a/t/141-keep-going/all.do
+++ b/t/141-keep-going/all.do
@@ -2,7 +2,7 @@ exec >&2
 . ../skip-if-minimal-do.sh
 
 rm -f out.log sort.log err.log
-redo --keep-going 1.ok 2.fail 3.fail 4.ok 5.ok 6.fail 7.ok >&err.log &&
+redo --keep-going 1.ok 2.fail 3.fail 4.ok 5.ok 6.fail 7.ok >err.log 2>&1 &&
    exit 11  # expect it to return nonzero due to failures
 sort out.log >sort.log
 

--- a/t/201-fail/all.do
+++ b/t/201-fail/all.do
@@ -1,14 +1,14 @@
 rm -f this-doesnt-exist
-! redo this-doesnt-exist >&/dev/null || exit 32  # expected to fail
-! redo-ifchange this-doesnt-exist >&/dev/null || exit 33  # expected to fail
-redo-ifcreate this-doesnt-exist >&/dev/null || exit 34  # expected to pass
+! redo this-doesnt-exist >/dev/null 2>&1 || exit 32  # expected to fail
+! redo-ifchange this-doesnt-exist >/dev/null 2>&1 || exit 33  # expected to fail
+redo-ifcreate this-doesnt-exist >/dev/null 2>&1 || exit 34  # expected to pass
 
 
 
 rm -f fail
-! redo-ifchange fail >&/dev/null || exit 44  # expected to fail
+! redo-ifchange fail >/dev/null 2>&1 || exit 44  # expected to fail
 
 touch fail
 ../flush-cache
 # since we created this file by hand, fail.do won't run, so it won't fail.
-redo-ifchange fail >&/dev/null || exit 55  # expected to pass
+redo-ifchange fail >/dev/null 2>&1 || exit 55  # expected to pass

--- a/t/999-installer/all.do
+++ b/t/999-installer/all.do
@@ -1,2 +1,2 @@
 rm -rf test.tmp
-DESTDIR=$PWD/test.tmp redo ../../install >&install.log
+DESTDIR=$PWD/test.tmp redo ../../install >install.log 2>&1


### PR DESCRIPTION
The >& form is only for file descriptors, passing a file name there is
a bash extension.

```
$ /bin/dash -c 'echo foo >&/dev/null'
/bin/dash: 1: Syntax error: Bad fd number
```
