### PR TITLE
escape $2 in generated `compile` script example

### DIFF
--- a/README.md
+++ b/README.md
@@ -853,7 +853,7 @@ create a file called `compile.do`:
 	
 	redo-ifchange config.sh
 	. ./config.sh
-	echo "gcc -c -o \$3 $2.c $CFLAGS" >$3
+	echo "gcc -c -o \$3 \$2.c $CFLAGS" >$3
 	chmod a+x $3
 
 Then, your `default.o.do` can simply look like this:


### PR DESCRIPTION
This fixes an example about computer-generated `compile` script.
