### PR TITLE
Use os.path.realpath to allow symlinking from e.g. /opt/redo/bin into /usr/local/bin

### DIFF
--- a/install.do
+++ b/install.do
@@ -39,7 +39,7 @@ for dd in redo*.py; do
 	cat >install.wrapper <<-EOF
 		#!/usr/bin/python
 		import sys, os;
-		exedir = os.path.dirname(os.path.abspath(sys.argv[0]))
+		exedir = os.path.dirname(os.path.realpath(os.path.abspath(sys.argv[0])))
 		sys.path.insert(0, os.path.join(exedir, '../lib/redo'))
 		import $fix
 	EOF


### PR DESCRIPTION
# Reproduction steps

```sh
PREFIX=/opt/redo ./redo install
ln -sf /opt/redo/bin/* /usr/local/bin/.
```

# Expected outcome

Running `redo` should work

# Actual outcome

Running `redo` complains about an unavailable module

# Remedy

Set path by expanding symlinks to find the canonical path to the invoked executable.