### PR TITLE
Replaced all instances of 'python' with 'python2'

### DIFF
--- a/Documentation/md2man.py
+++ b/Documentation/md2man.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 import sys, os, markdown, re
 from BeautifulSoup import BeautifulSoup
 

--- a/install.do
+++ b/install.do
@@ -26,7 +26,7 @@ for d in *.py version/*.py; do
 	fix=$(echo $d | sed 's,-,_,g')
 	$INSTALL -m 0644 $d $LIBDIR/$fix
 done
-python -mcompileall $LIBDIR
+python2 -mcompileall $LIBDIR
 
 # It's important for the file to actually be named 'sh'.  Some shells (like
 # bash and zsh) only go into POSIX-compatible mode if they have that name.
@@ -37,7 +37,7 @@ for dd in redo*.py; do
 	d=$(basename $dd .py)
 	fix=$(echo $d | sed -e 's,-,_,g')
 	cat >install.wrapper <<-EOF
-		#!/usr/bin/python
+		#!/usr/bin/python2
 		import sys, os;
 		exedir = os.path.dirname(os.path.realpath(os.path.abspath(sys.argv[0])))
 		sys.path.insert(0, os.path.join(exedir, '../lib/redo'))

--- a/redo-always.py
+++ b/redo-always.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 import sys, os
 import vars, state
 from log import err

--- a/redo-ifchange.py
+++ b/redo-ifchange.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 import sys, os
 
 import vars_init

--- a/redo-ifcreate.py
+++ b/redo-ifcreate.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 import sys, os
 import vars, state
 from log import err

--- a/redo-ood.py
+++ b/redo-ood.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 import sys, os
 
 import vars_init

--- a/redo-sources.py
+++ b/redo-sources.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 import sys, os
 
 import vars_init

--- a/redo-stamp.py
+++ b/redo-stamp.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 import sys, os
 import vars, state
 from log import err, debug2

--- a/redo-targets.py
+++ b/redo-targets.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 import sys, os
 
 import vars_init

--- a/redo-unlocked.py
+++ b/redo-unlocked.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 import sys, os
 import state
 from log import err

--- a/redo-whichdo.py
+++ b/redo-whichdo.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 import sys, os
 
 import vars_init

--- a/redo.py
+++ b/redo.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 import sys, os
 import options
 from helpers import atoi

--- a/t/101-atime/tick
+++ b/t/101-atime/tick
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 import time
 
 t1 = int(time.time())

--- a/t/130-mode/all.do
+++ b/t/130-mode/all.do
@@ -1,5 +1,5 @@
 umask 0022
 redo mode1
-MODE=$(python -c 'import os; print oct(os.stat("mode1").st_mode & 07777)')
+MODE=$(python2 -c 'import os; print oct(os.stat("mode1").st_mode & 07777)')
 [ "$MODE" = "0644" ] || exit 78
 

--- a/t/flush-cache
+++ b/t/flush-cache
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 import sys, os, sqlite3
 
 if "DO_BUILT" in os.environ:


### PR DESCRIPTION
On systems where 'python' refers to python3, redo
failed to launch. All invocations of python have been
made explicitly python2 invocations. All tests pass
on an Arch Linux system as of this commit.