### PR TITLE
Avoid symlinking to /bin/true in minimal/do, which fails when /bin/true is busybox

### DIFF
--- a/minimal/do
+++ b/minimal/do
@@ -103,10 +103,10 @@ if [ -z "$DO_BUILT" -a "$_cmd" != "redo-whichdo" ]; then
 	for d in redo redo-ifchange redo-whichdo; do
 		ln -s "$REDO" "$DO_PATH/$d"
 	done
-	[ -e /bin/true ] && TRUE=/bin/true || TRUE=/usr/bin/true
 	for d in redo-ifcreate redo-stamp redo-always redo-ood \
 	    redo-targets redo-sources; do
-		ln -s $TRUE "$DO_PATH/$d"
+	        echo : > "$DO_PATH/$d"
+		chmod a+rx "$DO_PATH/$d"
 	done
 fi
 


### PR DESCRIPTION
Installing redo on Alpine (which uses busybox for most everything incl /bin/true) yields an error,

```
redo-always: applet not found
```

because minimal/do symlinks /bin/true to redo-always, and /bin/true is in turn a link to busybox, which uses `$0` to figure out what to do.

This PR changes minimal/do, making it create a +x file containing just ":" instead of symlinking to /bin/true.