### PR TITLE
Fix directory nonexistent issue

### DIFF
--- a/minimal/do
+++ b/minimal/do
@@ -382,6 +382,7 @@ _do()
 			echo "$PWD/$target" >>"$DO_BUILT"
 			if [ ! -e "$tmp" ]; then
 				# if $3 wasn't created, copy from stdout file
+				mkdir -p "$(qdirname "$tmp")"
 				cat <&4 >$tmp
 				# if that's zero length too, forget it
 				[ -s "$tmp" ] || rm -f "$tmp"


### PR DESCRIPTION
I found the minimal do fails with directory nonexistent in some case when the full redo works fine. This PR fixes the issue.

A minimal repro with the instructions are available at https://github.com/maoe/minimal-do-repro.

Although the issue goes away with this fix, I'm not really sure if this is the right way. Please let me know if there's a better way to fix the issue.