### PR TITLE
Remove absolute pathnames to binaries and rely on PATH

### DIFF
--- a/do
+++ b/do
@@ -24,7 +24,7 @@ usage() {
 }
 
 mydir=$(dirname "$0")
-cd "$(/bin/pwd)" && cd "$mydir" || die "can't find self in dir: $mydir"
+cd "$(env pwd)" && cd "$mydir" || die "can't find self in dir: $mydir"
 
 args=
 while [ "$1" != "${1#-}" ]; do

--- a/minimal/do
+++ b/minimal/do
@@ -54,7 +54,7 @@ qdirname() (
 )
 
 _dirsplit "$0"
-REDO=$(cd "$(pwd -P)" &&
+REDO=$(cd "$(env pwd -P)" &&
 	cd "${_dirsplit_dir:-.}" &&
 	echo "$PWD/$_dirsplit_base")
 export REDO
@@ -89,7 +89,7 @@ if [ -z "$DO_BUILT" -a "$_cmd" != "redo-whichdo" ]; then
 	if [ "$#" -eq 0 ] && [ "$_cmd" = "do" -o "$_cmd" = "redo" ]; then
 		set all  # only toplevel redo has a default target
 	fi
-	export DO_STARTDIR="$(pwd -P)"
+	export DO_STARTDIR="$(env pwd -P)"
 	# If starting /bin/pwd != $PWD, this will fix it.
 	# That can happen when $PWD contains symlinks that the shell is
 	# trying helpfully (but unsuccessfully) to hide from the user.
@@ -228,7 +228,7 @@ _realpath()
 			#echo "Trying: $PWD--$path" >&2
 			if cd -P "$path" 2>/dev/null; then
 				# success
-				pwd=$(pwd -P)
+				pwd=$(env pwd -P)
 				#echo "  chdir ok: $pwd--$rest" >&2
 				np=$(_normpath "${pwd%/}/$rest" "$relto")
 				if [ -n "$isabs" ]; then

--- a/minimal/do.test
+++ b/minimal/do.test
@@ -136,9 +136,9 @@ mkdir y
 ln -s . y/x
 check "/usr/__does_not/b"  _realpath "/usr/__does_not/a/../b" "$x"
 check "foo"  _realpath "y/x/x/x/x/x/../foo" "$PWD"
-check "$(/bin/pwd)/foo"  _realpath "$PWD/y/x/x/x/x/x/../foo" "$PWD"
+check "$(env pwd)/foo"  _realpath "$PWD/y/x/x/x/x/x/../foo" "$PWD"
 check "foo/blam"  _realpath "y/x/x/x/x/x/../foo/spam/../blam" "$PWD"
-check "$(/bin/pwd)/foo/blam"  _realpath "$PWD/y/x/x/../foo/spam/../blam" "$PWD"
+check "$(env pwd)/foo/blam"  _realpath "$PWD/y/x/x/../foo/spam/../blam" "$PWD"
 
 
 SECTION _find_dofile

--- a/t/105-sympath/all.do
+++ b/t/105-sympath/all.do
@@ -14,10 +14,10 @@ for iter in 10 20; do
 		cd y/x/x/x/x/x
 		IFS=$(printf '\n')
 		redo-ifchange static x/x/x/static $PWD/static \
-			$(/bin/pwd)/static /etc/passwd
+			$(env pwd)/static /etc/passwd
 		redo-ifchange $PWD/../static 2>/dev/null && exit 35
 		redo-ifchange 1.dyn x/x/x/2.dyn $PWD/3.dyn \
-			 $PWD/../4.dyn $(/bin/pwd)/5.dyn
+			 $PWD/../4.dyn $(env pwd)/5.dyn
 	)
 	[ -e y/1.dyn ] || exit $((iter + 1))
 	[ -e y/2.dyn ] || exit $((iter + 2))

--- a/t/all.do
+++ b/t/all.do
@@ -10,13 +10,13 @@ fi
 
 # builds 1xx*/all to test for basic/dangerous functionality.
 # We don't want to run more advanced tests if the basics don't work.
-/bin/ls 1[0-9][0-9]*/all.do |
+ls 1[0-9][0-9]*/all.do |
 sed 's/\.do$//' |
 xargs redo
 110-compile/hello >&2
 
 # builds most of the rest in parallel
-/bin/ls [2-9][0-9][0-9]*/all.do |
+ls [2-9][0-9][0-9]*/all.do |
 sed 's/\.do$//' |
 xargs redo
 
@@ -25,7 +25,7 @@ xargs redo
 # are checking for unnecessary extra rebuilds of some targets, which
 # might happen after flush-cache.
 # FIXME: a better solution might be to make flush-cache less destructive!
-/bin/ls [s][0-9][0-9]*/all.do |
+ls [s][0-9][0-9]*/all.do |
 sed 's/\.do$//' | {
     while read d; do
         redo "$d"

--- a/t/clean.do
+++ b/t/clean.do
@@ -1,4 +1,4 @@
-/bin/ls [0-9s][0-9][0-9]*/clean.do |
+ls [0-9s][0-9][0-9]*/clean.do |
 sed 's/\.do$//' |
 xargs redo
 

--- a/t/shelltest.od
+++ b/t/shelltest.od
@@ -526,8 +526,8 @@ rm -f shlink ../shlink
 ln -s . shlink
 (quiet_stderr cd -L shlink/shlink/shlink/../shlink) || fail 120
 (quiet_stderr cd -P shlink/shlink/shlink/../shlink) && fail 121
-x1=$(cd shlink && basename "$(pwd -P)")
-x2=$(cd shlink && basename "$(pwd -L)")
+x1=$(cd shlink && basename "$(env pwd -P)")
+x2=$(cd shlink && basename "$(env pwd -L)")
 [ "$x1" = "t" ] || fail 122
 [ "$x2" = "shlink" ] || fail 123
 


### PR DESCRIPTION
 Fixes issues with distributions that use non-standard binary paths (e.g., in
 isolated build environments). Scripts rely on PATH for other programs, anyway.