### PR TITLE
GettingStarted.md: Add -E option to sudo to preserve environment

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -26,7 +26,7 @@ If the tests pass, you can either add $PWD/redo/bin to your PATH, or install
 redo on your system.  To install for all users, put it in /usr/local:
 
 ```sh
-	DESTDIR= PREFIX=/usr/local sudo ./do install
+	DESTDIR= PREFIX=/usr/local sudo -E ./do install
 ```
 
 Or to install it just for yourself (without needing root access), put it in


### PR DESCRIPTION
Sudo does not always preserve the environment so when doing the install with sudo and a DESTDIR= it will not be set in the sudo session. This makes install fail. This can be fixed by adding the -E option to sudo.