### PR TITLE
FIX default.required.rc.od to save changes

### DIFF
--- a/redoconf/rc/default.required.rc.od
+++ b/redoconf/rc/default.required.rc.od
@@ -9,3 +9,4 @@ if [ -z "$v" ]; then
 	echo "$NAME is required in order to build." >&2
 	exit 1
 fi
+rc_save


### PR DESCRIPTION
The `default.required.rc.od` modifier seems to be broken in the current build.  It does not allow variables which have been modified in targets using appendln or replaceln to actually propagate upward to the file which calls `include mytarget.required.rc`.  I added an `rc_save` call after the successful evaluation of base target and it appears to work as expected now.