### PR TITLE
minimal/do: allow for relative shebangs

### DIFF
--- a/minimal/do
+++ b/minimal/do
@@ -4,7 +4,7 @@
 # For the full version, visit http://github.com/apenwarr/redo
 #
 # The author disclaims copyright to this source file and hereby places it in
-# the public domain. (2010 12 14; updated 2019 02 24)
+# the public domain. (2010 12 14; updated 2021 08 06)
 #
 USAGE="
 usage: do [-d] [-x] [-v] [-c] <targets...>
@@ -315,10 +315,10 @@ _run_dofile()
 	local line1
 	set -e
 	read line1 <"$PWD/$dofile" || true
-	cmd=${line1#"#!/"}
+	cmd=${line1#"#!"}
 	if [ "$cmd" != "$line1" ]; then
 		set -$_do_opt_verbose$_do_opt_exec
-		exec /$cmd "$PWD/$dofile" "$@"
+		exec $cmd "$PWD/$dofile" "$@"
 	else
 		set -$_do_opt_verbose$_do_opt_exec
 		# If $dofile is empty, "." might not change $? at


### PR DESCRIPTION
The current version of do expects #! to be followed by a /. A variety of
tested systems treat the first word which follows #! as a path (which
could be absolute or relative). Additionally, #! can be followed by
spaces before the first path character. This patch addresses this
potential incompatibility as a side effect.

An example usecase of relative paths in shebang in a redo based build
system can be seen here:

https://git.sr.ht/~tk/pack/commit/01438f00d44adf33f59da729b347eca60cb461a8

This patch was tested to work in a variety of situations and systems.

Possibly mandatory legalese: I disclaim any copyright to this patch thereby placing it in the public domain, in line with the public domain status of minimal/do.