### PR TITLE
Update reference to redo-c

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -217,7 +217,7 @@ collecting many of these links):
   be simple and failsafe, so it doesn't understand how to "redo" targets more
   than once.
 
-- Christian Neukirchen's [redo-c](https://github.com/chneukirchen/redo-c), a
+- Leah Neukirchen's [redo-c](https://github.com/leahneukirchen/redo-c), a
   C implementation.
 
 - Jonathan de Boyne Pollard's [fork of Alan Grosskurth's redo](http://jdebp.eu./Softwares/redo/grosskurth-redo.html)


### PR DESCRIPTION
The author of redo-c is called Leah Neukirchen. See redirect of the Github profile 😃 