### PR TITLE
make install.do not try changing permissions of existing directories

### DIFF
--- a/install.do
+++ b/install.do
@@ -19,8 +19,11 @@ read py <redo/whichpython
 echo "Installing to: $DESTDIR$PREFIX"
 
 # make dirs
-"$INSTALL" -d "$MANDIR/man1" "$DOCDIR" "$BINDIR" \
+for d in "$MANDIR/man1" "$DOCDIR" "$BINDIR" \
 	"$LIBDIR" "$LIBDIR/version"
+do
+  if [ ! -d "$d" ]; then "$INSTALL" -d "$d"; fi
+done
 
 # docs
 for d in docs/*.1; do


### PR DESCRIPTION
Except when necessary, I prefer not to install into /usr/local as root.
My setup is as follows:

```
$ ls -ld /usr/local/bin /usr/local/share/man/man1
drwxrwsr-x 3 root staff 4096 Jun  8 11:29 /usr/local/bin
drwxrwsr-x 2 root staff 4096 Oct 12  2021 /usr/local/share/man/man1
```

Since I'm a member of the `staff` group it all works out.
But running `do` on `install.do` failed with an error message:

```
Installing to: /usr/local
install: cannot change permissions of ‘/usr/local/share/man/man1’: Operation not permitted
install: cannot change permissions of ‘/usr/local/bin’: Operation not permitted
```

This change calls `"$INSTALL"` only when the directory to be installed
isn't already there.