### PR TITLE
minimal/do: Make `redo-stamp` consume all of its stdin

### DIFF
--- a/minimal/do
+++ b/minimal/do
@@ -118,6 +118,7 @@ if [ -z "$DO_BUILT" -a "$_cmd" != "redo-whichdo" ]; then
 	        echo "#!/bin/sh" >"$DO_PATH/$d"
 		chmod a+rx "$DO_PATH/$d"
 	done
+	echo "cat >/dev/null" >>"$DO_PATH/redo-stamp"
 fi
 
 


### PR DESCRIPTION
Otherwise, other processes may fail to write to its stdin, and fail; for example, `tee file | redo-stamp` can cause `tee` to fail and thus write nothing to `file`.